### PR TITLE
Fix README bullet typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LibraFetch is a specialised web scraping tool to automatically acquire documents
 - **Batch Downloading**:
   LibraFetch supports batch downloading, allowing users to save multiple documents simultaneously. This feature is especially valuable for researchers looking to compile extensive reading lists or archives.
 - **Robust PDF Handling**:
-  The downloader can handle various doaload formats, including OCR-processed documents and scanned images, ensuring that all types of content are accessible.
+  The downloader can handle various download formats, including OCR-processed documents and scanned images, ensuring that all types of content are accessible.
 - **Error Handling and Notifications**:
   The tool is equipped with error detection and handling mechanisms to address issues such as broken links, captcha challenges, or website changes. Users can set up notifications for exceptional cases.
 - **Data Storage Options**:


### PR DESCRIPTION
## Summary
- clarify robust PDF bullet description
- fix typo: `doload` -> `download`

## Testing
- `python -m py_compile scrape.py scrape_newsbank.py scrape_readex.py`

------
https://chatgpt.com/codex/tasks/task_e_685c01f1243c832c944f3bf615904dcf